### PR TITLE
Setup of a11y checks in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,7 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.config({
     ignorePatterns:"*/__mocks__/**/*.js",
-    extends: ["eslint:recommended","next/core-web-vitals", "next/typescript", "prettier"],
+    extends: ["eslint:recommended","next/core-web-vitals", "next/typescript","plugin:jsx-a11y/recommended", "prettier"],
     plugins: ["unused-imports"],
     rules:{
       "@typescript-eslint/no-unused-vars": ["warn", { 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^9.28.0",
         "eslint-config-next": "15.2.4",
         "eslint-config-prettier": "^10.1.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^9.28.0",
     "eslint-config-next": "15.2.4",
     "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
@@ -46,6 +47,6 @@
     "typescript": "^5"
   },
   "overrides": {
-     "glob": "10.4.5"
-   }
+    "glob": "10.4.5"
+  }
 }

--- a/src/components/icons/icons.tsx
+++ b/src/components/icons/icons.tsx
@@ -6,5 +6,5 @@ import { Icon } from "@trussworks/react-uswds";
 type AppIconProp = ComponentProps<"svg"> & { size: number };
 
 export const GithubIcon: React.FC<AppIconProp> = (props) => (
-  <Icon.Github {...props} role="" />
+  <Icon.Github {...props} />
 );


### PR DESCRIPTION
This PR adds `eslint-plugin-jsx-a11y` in the eslint configuration and fixes the error found in the icon component.