### PR TITLE
silence deprecation warnings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     includePaths: [
       path.join(__dirname, "./", "node_modules", "@uswds", "uswds", "packages"),
     ],
+    silenceDeprecations: ["global-builtin", "mixed-decls", "legacy-js-api"],
   },
 };
 


### PR DESCRIPTION
mutes the Sass compiler warnings we get from an incompatibility with the USWDS styles